### PR TITLE
Add config option to hide custom flags.

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -9,4 +9,6 @@
   $rcmail_config['tb_label_modify_labels'] = true;
   // style for UI: 'bullets' or 'thunderbird'
   $rcmail_config['tb_label_style'] = "bullets";
+  // custom hidden flags
+  $rcmail_config['tb_label_hidden_flags'] = array();
 

--- a/thunderbird_labels.php
+++ b/thunderbird_labels.php
@@ -466,7 +466,7 @@ class thunderbird_labels extends rcube_plugin
 			'\\*',  // means labels allowed
 			'*',  // means labels allowed roundcubed
 		];
-		// TODO: merge flags that should be hidden from tblabels config
+		$default_flags = array_unique(array_merge($default_flags, $this->rc->config->get('tb_label_hidden_flags', [])));
 
 		/* TODO: flagnames contain $ sign, or umlauts (imap-utf-7 encoded meanging & will be in the name)
 		* smart way to recode those characters and create valid variable names?


### PR DESCRIPTION
Mail.app from Mac OS X adds flags `$NotJunk` / `NotJunk` and the plugin is showing them with an `unknown` label. This PR enables the admin to hide certain flags in the config file (without touching the tb_labels code).