### PR TITLE
Update thunderbird_labels.php

### DIFF
--- a/thunderbird_labels.php
+++ b/thunderbird_labels.php
@@ -14,6 +14,9 @@ class thunderbird_labels extends rcube_plugin
 	private $rc;
 	private $map;
 	private $_custom_flags_allowed = null;
+	private $message_tb_labels;
+	private $name;
+	private $add_tb_flags;
 	const LABEL_STYLES = ['thunderbird', 'bullets', 'badges'];
 
 	function init()

--- a/thunderbird_labels.php
+++ b/thunderbird_labels.php
@@ -17,6 +17,7 @@ class thunderbird_labels extends rcube_plugin
 	private $message_tb_labels;
 	private $name;
 	private $add_tb_flags;
+	private $list_flags;
 	const LABEL_STYLES = ['thunderbird', 'bullets', 'badges'];
 
 	function init()


### PR DESCRIPTION
My error.log was flooded with "Creation of dynamic property thunderbird_labels::... is deprecated".
This is due to a deprecation in PHP 8.2: [https://www.php.net/releases/8.2/en.php#deprecate_dynamic_properties](https://www.php.net/releases/8.2/en.php#deprecate_dynamic_properties).
Earlier PHP versions work fine.
Cheers