### PR TITLE
Update thunderbird_labels.php

### DIFF
--- a/thunderbird_labels.php
+++ b/thunderbird_labels.php
@@ -14,6 +14,10 @@ class thunderbird_labels extends rcube_plugin
 	private $rc;
 	private $map;
 	private $_custom_flags_allowed = null;
+	private $message_tb_labels;
+	private $name;
+	private $add_tb_flags;
+	private $list_flags;
 	const LABEL_STYLES = ['thunderbird', 'bullets', 'badges'];
 
 	function init()


### PR DESCRIPTION
Avoid flooding the error.log with "Creation of dynamic property rcube_message_header::$... is deprecated".
This is due to [PHP 8.2 deprecating dynamic properties](https://www.php.net/releases/8.2/en.php#deprecate_dynamic_properties).
Earlier PHP versions work fine.
Cheers