### PR TITLE
Update thunderbird_labels.php

### DIFF
--- a/thunderbird_labels.php
+++ b/thunderbird_labels.php
@@ -14,6 +14,9 @@ class thunderbird_labels extends rcube_plugin
 	private $rc;
 	private $map;
 	private $_custom_flags_allowed = null;
+	private $name;
+	private $add_tb_flags;
+	private $message_tb_labels;
 	const LABEL_STYLES = ['thunderbird', 'bullets', 'badges'];
 
 	function init()


### PR DESCRIPTION
partially fixes PHP 8.2 deprecation of dynamic properties. PHP 9.0 will break everything.
$message->list_flags is still a dynamic property and there is nothing we can do here at the moment.