### PR TITLE
Issue #69 - Fix Classic skin

### DIFF
--- a/skins/classic/tb_label.css
+++ b/skins/classic/tb_label.css
@@ -173,7 +173,7 @@ div#labelbox span.tb_label_span5 {
     transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;
 }
 
-span.tb_label_dots {
+span.tb_label_dots.badges:not(:empty) {
 	margin: 3px 1.1em 1.5em 1.4em;
 	clear: both;
 	display: block;


### PR DESCRIPTION
The problem was that the space for the badges was being applied
a) irrespective of whether the "badges" style was active or not, and
b) even if the "badges style *was* actually the active style, irrespective of whether there were any badges to display for that specific message or not.